### PR TITLE
[ci-master-f30] Add Fedora 30 test definitions

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/nightly_master.yaml

--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -25,7 +25,7 @@ topologies:
     memory: 12900
 
 jobs:
-  fedora-30/build:
+  fedora-29/build:
     requires: []
     priority: 100
     job:
@@ -33,1198 +33,1198 @@ jobs:
       args:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
-        template: &ci-master-f30
-          name: freeipa/ci-master-f30
-          version: 0.0.1
+        template: &ci-master-f29
+          name: freeipa/ci-master-f29
+          version: 0.2.0
         timeout: 1800
         topology: *build
 
-  fedora-30/simple_replication:
-    requires: [fedora-30/build]
+  fedora-29/simple_replication:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_simple_replication.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_1:
-    requires: [fedora-30/build]
+  fedora-29/external_ca_1:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/external_ca_2:
-    requires: [fedora-30/build]
+  fedora-29/external_ca_2:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_external_ca.py::TestSelfExternalSelf test_integration/test_external_ca.py::TestExternalCAInstall
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_topologies:
-    requires: [fedora-30/build]
+  fedora-29/test_topologies:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_topologies.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_sudo:
-    requires: [fedora-30/build]
+  fedora-29/test_sudo:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_sudo.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_commands:
-    requires: [fedora-30/build]
+  fedora-29/test_commands:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_commands.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_kerberos_flags:
-    requires: [fedora-30/build]
+  fedora-29/test_kerberos_flags:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_kerberos_flags.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_http_kdc_proxy:
-    requires: [fedora-30/build]
+  fedora-29/test_http_kdc_proxy:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_http_kdc_proxy.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_forced_client_enrolment:
-    requires: [fedora-30/build]
+  fedora-29/test_forced_client_enrolment:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_forced_client_reenrollment.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_advise:
-    requires: [fedora-30/build]
+  fedora-29/test_advise:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_advise.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_testconfig:
-    requires: [fedora-30/build]
+  fedora-29/test_testconfig:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_testconfig.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_service_permissions:
-    requires: [fedora-30/build]
+  fedora-29/test_service_permissions:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_service_permissions.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_netgroup:
-    requires: [fedora-30/build]
+  fedora-29/test_netgroup:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_netgroup.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_vault:
-    requires: [fedora-30/build]
+  fedora-29/test_vault:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_vault.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 6300
         topology: *master_1repl
 
-  fedora-30/test_authconfig:
-    requires: [fedora-30/build]
+  fedora-29/test_authconfig:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_authselect.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 4800
         topology: *master_1repl_1client
 
-  fedora-30/test_server_del:
-    requires: [fedora-30/build]
+  fedora-29/test_server_del:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_server_del.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA1:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallWithCA1:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA1
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA2:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallWithCA2:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA2
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA1:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallWithCA_KRA1:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA1
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA2:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallWithCA_KRA2:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA2
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS1:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallWithCA_DNS1:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS1
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS2:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallWithCA_DNS2:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_DNS3:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallWithCA_DNS3:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS3
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallWithCA_DNS4:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallWithCA_DNS4:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS4
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallWithCA_KRA_DNS1:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallWithCA_KRA_DNS1:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS1
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallWithCA_KRA_DNS2:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallWithCA_KRA_DNS2:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallWithCA_KRA_DNS2
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_installation_TestInstallMaster:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallMaster:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMaster
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterKRA:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallMasterKRA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterKRA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterDNS:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallMasterDNS:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterDNS
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_installation_TestInstallMasterReservedIPasForwarder:
-    requires: [fedora-30/build]
+  fedora-29/test_installation_TestInstallMasterReservedIPasForwarder:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestInstallMasterReservedIPasForwarder
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_1repl
 
-  fedora-30/test_idviews:
-    requires: [fedora-30/build]
+  fedora-29/test_idviews:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_idviews.py::TestIDViews
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_caless_TestServerInstall:
-    requires: [fedora-30/build]
+  fedora-29/test_caless_TestServerInstall:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_caless.py::TestServerInstall
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 12000
         topology: *master_1repl
 
-  fedora-30/test_caless_TestReplicaInstall:
-    requires: [fedora-30/build]
+  fedora-29/test_caless_TestReplicaInstall:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaInstall
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestClientInstall:
-    requires: [fedora-30/build]
+  fedora-29/test_caless_TestClientInstall:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_caless.py::TestClientInstall
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 5400
         # actually master_1client
         topology: *master_1repl_1client
 
-  fedora-30/test_caless_TestIPACommands:
-    requires: [fedora-30/build]
+  fedora-29/test_caless_TestIPACommands:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_caless.py::TestIPACommands
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestCertInstall:
-    requires: [fedora-30/build]
+  fedora-29/test_caless_TestCertInstall:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_caless.py::TestCertInstall
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestPKINIT:
-    requires: [fedora-30/build]
+  fedora-29/test_caless_TestPKINIT:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_caless.py::TestPKINIT
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerReplicaCALessToCAFull:
-    requires: [fedora-30/build]
+  fedora-29/test_caless_TestServerReplicaCALessToCAFull:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestReplicaCALessToCAFull:
-    requires: [fedora-30/build]
+  fedora-29/test_caless_TestReplicaCALessToCAFull:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_caless.py::TestReplicaCALessToCAFull
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_caless_TestServerCALessToExternalCA:
-    requires: [fedora-30/build]
+  fedora-29/test_caless_TestServerCALessToExternalCA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_caless.py::TestServerCALessToExternalCA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 5400
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
-    requires: [fedora-30/build]
+  fedora-29/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestore:
-    requires: [fedora-30/build]
+  fedora-29/test_backup_and_restore_TestBackupAndRestore:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
-    requires: [fedora-30/build]
+  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
-    requires: [fedora-30/build]
+  fedora-29/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithDNS:
-    requires: [fedora-30/build]
+  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithDNS:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
-    requires: [fedora-30/build]
+  fedora-29/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithKRA:
-    requires: [fedora-30/build]
+  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
-    requires: [fedora-30/build]
+  fedora-29/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreWithReplica:
-    requires: [fedora-30/build]
+  fedora-29/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_backup_and_restore_TestBackupAndRestoreDMPassword:
-    requires: [fedora-30/build]
+  fedora-29/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_backup_and_restore_TestReplicaInstallAfterRestore:
-    requires: [fedora-30/build]
+  fedora-29/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_dnssec:
-    requires: [fedora-30/build]
+  fedora-29/test_dnssec:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_dnssec.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestReplicaPromotionLevel1:
-    requires: [fedora-30/build]
+  fedora-29/test_replica_promotion_TestReplicaPromotionLevel1:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestUnprivilegedUserPermissions:
-    requires: [fedora-30/build]
+  fedora-29/test_replica_promotion_TestUnprivilegedUserPermissions:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestUnprivilegedUserPermissions
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestProhibitReplicaUninstallation:
-    requires: [fedora-30/build]
+  fedora-29/test_replica_promotion_TestProhibitReplicaUninstallation:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestWrongClientDomain:
-    requires: [fedora-30/build]
+  fedora-29/test_replica_promotion_TestWrongClientDomain:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestWrongClientDomain
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestRenewalMaster:
-    requires: [fedora-30/build]
+  fedora-29/test_replica_promotion_TestRenewalMaster:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestRenewalMaster
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestReplicaInstallWithExistingEntry:
-    requires: [fedora-30/build]
+  fedora-29/test_replica_promotion_TestReplicaInstallWithExistingEntry:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallWithExistingEntry
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestSubCAkeyReplication:
-    requires: [fedora-30/build]
+  fedora-29/test_replica_promotion_TestSubCAkeyReplication:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestSubCAkeyReplication
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestReplicaInstallCustodia:
-    requires: [fedora-30/build]
+  fedora-29/test_replica_promotion_TestReplicaInstallCustodia:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInstallCustodia
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_replica_promotion_TestReplicaInForwardZone:
-    requires: [fedora-30/build]
+  fedora-29/test_replica_promotion_TestReplicaInForwardZone:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestReplicaInForwardZone
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_replica_promotion_TestHiddenReplicaPromotion:
-    requires: [fedora-30/build]
+  fedora-29/test_replica_promotion_TestHiddenReplicaPromotion:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_2repl_1client
 
-  fedora-30/test_upgrade:
-    requires: [fedora-30/build]
+  fedora-29/test_upgrade:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_upgrade.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl
 
-  fedora-30/test_topology_TestCASpecificRUVs:
-    requires: [fedora-30/build]
+  fedora-29/test_topology_TestCASpecificRUVs:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_topology.py::TestCASpecificRUVs
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_topology_TestTopologyOptions:
-    requires: [fedora-30/build]
+  fedora-29/test_topology_TestTopologyOptions:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_topology.py::TestTopologyOptions
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithoutCA:
-    requires: [fedora-30/build]
+  fedora-29/test_replication_layouts_TestLineTopologyWithoutCA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCA:
-    requires: [fedora-30/build]
+  fedora-29/test_replication_layouts_TestLineTopologyWithCA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestLineTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  fedora-29/test_replication_layouts_TestLineTopologyWithCAKRA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts.py_TestStarTopologyWithoutCA:
-    requires: [fedora-30/build]
+  fedora-29/test_replication_layouts.py_TestStarTopologyWithoutCA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCA:
-    requires: [fedora-30/build]
+  fedora-29/test_replication_layouts_TestStarTopologyWithCA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestStarTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  fedora-29/test_replication_layouts_TestStarTopologyWithCAKRA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 10800
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithoutCA:
-    requires: [fedora-30/build]
+  fedora-29/test_replication_layouts_TestCompleteTopologyWithoutCA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCA:
-    requires: [fedora-30/build]
+  fedora-29/test_replication_layouts_TestCompleteTopologyWithCA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_replication_layouts_TestCompleteTopologyWithCAKRA:
-    requires: [fedora-30/build]
+  fedora-29/test_replication_layouts_TestCompleteTopologyWithCAKRA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_3repl_1client
 
-  fedora-30/test_client_uninstallation:
-    requires: [fedora-30/build]
+  fedora-29/test_client_uninstallation:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_uninstallation.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-30/test_user_permissions:
-    requires: [fedora-30/build]
+  fedora-29/test_user_permissions:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_user_permissions.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl_1client
 
-  fedora-30/test_webui_cert:
-    requires: [fedora-30/build]
+  fedora-29/test_webui_cert:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_webui/test_cert.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 2400
         topology: *ipaserver
 
-  fedora-30/test_webui_general:
-    requires: [fedora-30/build]
+  fedora-29/test_webui_general:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: >-
           test_webui/test_loginscreen.py
           test_webui/test_misc_cases.py
           test_webui/test_navigation.py
           test_webui/test_translation.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_host:
-    requires: [fedora-30/build]
+  fedora-29/test_webui_host:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_webui/test_host.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_host_net_groups:
-    requires: [fedora-30/build]
+  fedora-29/test_webui_host_net_groups:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: >-
           test_webui/test_hostgroup.py
           test_webui/test_netgroup.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_identity:
-    requires: [fedora-30/build]
+  fedora-29/test_webui_identity:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: >-
           test_webui/test_automember.py
           test_webui/test_idviews.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_network:
-    requires: [fedora-30/build]
+  fedora-29/test_webui_network:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: >-
           test_webui/test_automount.py
           test_webui/test_dns.py
           test_webui/test_vault.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_policy:
-    requires: [fedora-30/build]
+  fedora-29/test_webui_policy:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: >-
           test_webui/test_hbac.py
           test_webui/test_krbtpolicy.py
           test_webui/test_pwpolicy.py
           test_webui/test_selinuxusermap.py
           test_webui/test_sudo.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_rbac:
-    requires: [fedora-30/build]
+  fedora-29/test_webui_rbac:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: >-
           test_webui/test_delegation.py
           test_webui/test_rbac.py
           test_webui/test_selfservice.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_server:
-    requires: [fedora-30/build]
+  fedora-29/test_webui_server:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: >-
           test_webui/test_config.py
           test_webui/test_range.py
           test_webui/test_realmdomains.py
           test_webui/test_trust.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *ipaserver
 
-  fedora-30/test_webui_service:
-    requires: [fedora-30/build]
+  fedora-29/test_webui_service:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_webui/test_service.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 2400
         topology: *ipaserver
 
-  fedora-30/test_webui_users:
-    requires: [fedora-30/build]
+  fedora-29/test_webui_users:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunWebuiTests
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: >-
           test_webui/test_group.py
           test_webui/test_user.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 4800
         topology: *ipaserver
 
-  fedora-30/customized_ds_config_install:
-    requires: [fedora-30/build]
+  fedora-29/customized_ds_config_install:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_customized_ds_config_install.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/dns_locations:
-    requires: [fedora-30/build]
+  fedora-29/dns_locations:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_dns_locations.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_2repl_1client
 
-  fedora-30/external_ca_TestExternalCAdirsrvStop:
-    requires: [fedora-30/build]
+  fedora-29/external_ca_TestExternalCAdirsrvStop:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_TestExternalCAInvalidCert:
-    requires: [fedora-30/build]
+  fedora-29/external_ca_TestExternalCAInvalidCert:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_external_ca.py::TestExternalCAInvalidCert test_integration/test_external_ca.py::TestExternalCAInvalidIntermediate
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/external_ca_TestMultipleExternalCA:
-    requires: [fedora-30/build]
+  fedora-29/external_ca_TestMultipleExternalCA:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_external_ca.py::TestMultipleExternalCA
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_ntp_options:
-    requires: [fedora-30/build]
+  fedora-29/test_ntp_options:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_ntp_options.py::TestNTPoptions
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 7200
         topology: *master_1repl_1client
 
-  fedora-30/test_pkinit_manage:
-    requires: [fedora-30/build]
+  fedora-29/test_pkinit_manage:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_pkinit_manage.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/test_pki_config_override:
-    requires: [fedora-30/build]
+  fedora-29/test_pki_config_override:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_pki_config_override.py
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
 
-  fedora-30/nfs:
-    requires: [fedora-30/build]
+  fedora-29/nfs:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_nfs.py::TestNFS
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 9000
         topology: *master_3repl_1client
 
-  fedora-30/mask:
-    requires: [fedora-30/build]
+  fedora-29/mask:
+    requires: [fedora-29/build]
     priority: 50
     job:
       class: RunPytest
       args:
-        build_url: '{fedora-30/build_url}'
+        build_url: '{fedora-29/build_url}'
         test_suite: test_integration/test_installation.py::TestMaskInstall
-        template: *ci-master-f30
+        template: *ci-master-f29
         timeout: 3600
         topology: *ipaserver


### PR DESCRIPTION
Move nightly_master.yaml test definitions to nightly_fedora29.yaml.