### PR TITLE
[ci-master-f29] Test latest PR-CI changes

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/nightly_master.yaml

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f29
           name: freeipa/ci-master-f29
-          version: 0.2.0
+          version: 0.2.1
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
The goal of this PR is to make sure recent changes (https://github.com/freeipa/freeipa-pr-ci/commit/f181d0b6e09e239e370edc2b909c98c30f28f33b) in PR-CI don't break current test definitions.