### PR TITLE
[ci-master-f28] Bump Fedora 28 image

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/nightly_f28.yaml

--- a/ipatests/prci_definitions/nightly_f28.yaml
+++ b/ipatests/prci_definitions/nightly_f28.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f28
           name: freeipa/ci-master-f28
-          version: 0.2.0
+          version: 0.2.1
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Testing if recent PR-CI changes are breaking any test.