### PR TITLE
[ipa-4-7-master] Bump ipa-4-7 image version

### DIFF
--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -35,7 +35,7 @@ jobs:
         git_refspec: '{git_refspec}'
         template: &ci-master-f29
           name: freeipa/ci-master-f29
-          version: 0.2.0
+          version: 0.2.1
         timeout: 1800
         topology: *build
 


### PR DESCRIPTION
Testing PR-CI - Fedora 29