### PR TITLE
ipatests - test_cli_ipa_not_configured created and implemented test  for BZ1428690

### DIFF
--- a/ipatests/prci_definitions/nightly_f29.yaml
+++ b/ipatests/prci_definitions/nightly_f29.yaml
@@ -1280,3 +1280,15 @@ jobs:
         template: *ci-master-f29
         timeout: 3600
         topology: *master_1repl
+
+  fedora-29/test_integration_TestIPANotConfigured:
+    requires: [fedora-29/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-29/build_url}'
+        test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
+        template: *ci-master-f29
+        timeout: 10800
+        topology: *ipaserver

--- a/ipatests/prci_definitions/nightly_master.yaml
+++ b/ipatests/prci_definitions/nightly_master.yaml
@@ -1292,3 +1292,15 @@ jobs:
         template: *ci-master-f30
         timeout: 3600
         topology: *master_1repl
+
+  fedora-30/test_integration_TestIPANotConfigured:
+    requires: [fedora-30/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-30/build_url}'
+        test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
+        template: *ci-master-f30
+        timeout: 10800
+        topology: *ipaserver

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1292,3 +1292,15 @@ jobs:
         template: *ci-master-frawhide
         timeout: 3600
         topology: *master_1repl
+
+  fedora-rawhide/test_integration_TestIPANotConfigured:
+    requires: [fedora-rawhide/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-rawhide/build_url}'
+        test_suite: test_integration/test_cli_ipa_not_configured.py::TestIPANotConfigured
+        template: *ci-master-frawhide
+        timeout: 10800
+        topology: *ipaserver

--- a/ipatests/test_integration/test_cli_ipa_not_configured.py
+++ b/ipatests/test_integration/test_cli_ipa_not_configured.py
@@ -1,0 +1,24 @@
+from ipapython.admintool import SERVER_NOT_CONFIGURED
+from ipatests.test_integration.base import IntegrationTest
+
+
+class TestIPANotConfigured(IntegrationTest):
+    """
+    Test class for CLI commands with ipa server not configured.
+    Topology parameter is omitted in order to prevent IPA from configuring.
+    """
+
+    def test_var_log_message_with_ipa_backup(self):
+        """
+        Test for PG6843: ipa-backup does not create log file at /var/log
+        Launches ipa backup command on system with ipa server not configured.
+        As the server is not configured yet, command should fail and stderr
+        should not contain link to /var/log, as no such log is created.
+        Issue URl: https://pagure.io/freeipa/issue/6843
+        """
+        exp_str = "not configured on this system"
+        unexp_str = "/var/log"
+        cmd = self.master.run_command(["ipa-backup"], raiseonerr=False)
+        assert (exp_str in cmd.stderr_text and
+                cmd.returncode == SERVER_NOT_CONFIGURED and
+                unexp_str not in cmd.stderr_text)


### PR DESCRIPTION
When ipa server is not configured and ipa backup is invoked, command
should fail with "not configured" message which should not contain any
link to /var/log as this is not created at this point
    
 https://pagure.io/freeipa/issue/6843

 test_var_log_message_with_ipa_backup (BZ1428690) as xfail
    
 not-configured ipa server should return exit code 2 (SERVER_NOT_CONFIGURED from ipapython.admintool), but returns 1.
