### PR TITLE
ipatests: generic uninstall should call ipa server-del

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/nightly_latest.yaml

--- a/ipaplatform/debian/paths.py
+++ b/ipaplatform/debian/paths.py
@@ -93,7 +93,7 @@ class DebianPathNamespace(BasePathNamespace):
     HTTPD = "/usr/sbin/apache2ctl"
     FONTS_DIR = "/usr/share/fonts/truetype"
     FONTS_OPENSANS_DIR = "/usr/share/fonts/truetype/open-sans"
-    FONTS_FONTAWESOME_DIR = "/usr/share/fonts/truetype/fontawesome"
+    FONTS_FONTAWESOME_DIR = "/usr/share/fonts/truetype/font-awesome"
     VAR_KERBEROS_KRB5KDC_DIR = "/var/lib/krb5kdc/"
     VAR_KRB5KDC_K5_REALM = "/var/lib/krb5kdc/.k5."
     CACERT_PEM = "/var/lib/ipa/certs/cacert.pem"

--- a/ipatests/prci_definitions/nightly_latest.yaml
+++ b/ipatests/prci_definitions/nightly_latest.yaml
@@ -1395,4 +1395,4 @@ jobs:
         test_suite: test_integration/test_krbtpolicy.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_latest_testing.yaml
+++ b/ipatests/prci_definitions/nightly_latest_testing.yaml
@@ -1491,4 +1491,4 @@ jobs:
         test_suite: test_integration/test_krbtpolicy.py
         template: *testing-master-latest
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_previous.yaml
+++ b/ipatests/prci_definitions/nightly_previous.yaml
@@ -1371,4 +1371,4 @@ jobs:
         test_suite: test_integration/test_krbtpolicy.py
         template: *ci-master-previous
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl

--- a/ipatests/prci_definitions/nightly_rawhide.yaml
+++ b/ipatests/prci_definitions/nightly_rawhide.yaml
@@ -1395,4 +1395,4 @@ jobs:
         test_suite: test_integration/test_krbtpolicy.py
         template: *ci-master-frawhide
         timeout: 3600
-        topology: *ipaserver
+        topology: *master_1repl

--- a/ipatests/test_integration/base.py
+++ b/ipatests/test_integration/base.py
@@ -97,9 +97,12 @@ class IntegrationTest:
 
     @classmethod
     def uninstall(cls, mh):
-        tasks.uninstall_master(cls.master)
         for replica in cls.replicas:
+            tasks.run_server_del(
+                cls.master, replica.hostname, force=True,
+                ignore_topology_disconnect=True, ignore_last_of_role=True)
             tasks.uninstall_master(replica)
+        tasks.uninstall_master(cls.master)
         for client in cls.clients:
             tasks.uninstall_client(client)
         if cls.fips_mode:

--- a/ipatests/test_integration/test_crlgen_manage.py
+++ b/ipatests/test_integration/test_crlgen_manage.py
@@ -302,3 +302,8 @@ class TestCRLGenManage(IntegrationTest):
         check_crlgen_enable(self.replicas[0])
         # call uninstall without --ignore-last-of-role, should be OK
         self.master.run_command(['ipa-server-install', '--uninstall', '-U'])
+
+    @classmethod
+    def uninstall(cls, mh):
+        # Clean up was already done
+        pass

--- a/ipatests/test_integration/test_crlgen_manage.py
+++ b/ipatests/test_integration/test_crlgen_manage.py
@@ -290,6 +290,10 @@ class TestCRLGenManage(IntegrationTest):
         expected_msg = "Deleting this server will leave your installation " \
                        "without a CRL generation master"
         assert expected_msg in result.stdout_text
+        tasks.run_server_del(
+            self.replicas[0], self.master.hostname, force=True,
+            ignore_topology_disconnect=True,
+            ignore_last_of_role=True)
 
     def test_uninstall_last_master_does_not_require_ignore_last_of_role(self):
         """Test uninstallation of the last master
@@ -301,7 +305,8 @@ class TestCRLGenManage(IntegrationTest):
         # Make sure CRL gen is enabled on the replica
         check_crlgen_enable(self.replicas[0])
         # call uninstall without --ignore-last-of-role, should be OK
-        self.master.run_command(['ipa-server-install', '--uninstall', '-U'])
+        self.replicas[0].run_command(
+            ['ipa-server-install', '--uninstall', '-U'])
 
     @classmethod
     def uninstall(cls, mh):

--- a/ipatests/test_integration/test_ntp_options.py
+++ b/ipatests/test_integration/test_ntp_options.py
@@ -388,3 +388,8 @@ class TestNTPoptions(IntegrationTest):
         tasks.uninstall_client(self.client)
         tasks.uninstall_master(self.replica)
         tasks.uninstall_master(self.master)
+
+    @classmethod
+    def uninstall(cls, mh):
+        # Cleanup already done in teardown_method
+        pass

--- a/ipatests/test_integration/test_uninstallation.py
+++ b/ipatests/test_integration/test_uninstallation.py
@@ -119,3 +119,8 @@ class TestUninstallBase(IntegrationTest):
             self.master.run_command([
                 paths.DSCTL, serverid, 'remove', '--do-it'
             ])
+
+    @classmethod
+    def uninstall(cls, mh):
+        # Cleanup was already done earlier
+        pass


### PR DESCRIPTION
At the end of any integration test, the method uninstall is called and
uninstalls master, replicas and clients.
Usually the master is the CA renewal master and DNSSec master, and
uninstallation may fail.
This commits modifies the uninstall method in order to:
- call 'ipa server-del replica' before running uninstall on a replica
- uninstall the replicas before uninstalling the master

Fixes: https://pagure.io/freeipa/issue/7985
