### PR TITLE
Test dev version of 389ds

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/nightly_latest_389ds.yaml

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -34,7 +34,7 @@ jobs:
         git_repo: '{git_repo}'
         git_refspec: '{git_refspec}'
         template: &389ds-master-latest
-          name: freeipa/389ds-master-f31
+          name: netoarmando/custom-master-f31
           version: 0.0.1
         timeout: 1800
         topology: *build


### PR DESCRIPTION
Related to: https://pagure.io/389-ds-base/pull-request/50769

Packages installed: 
- `389-ds-base-1.4.2.5-20191213git9104539a0.fc31.x86_64`
- `389-ds-base-libs-1.4.2.5-20191213git9104539a0.fc31.x86_64`

Signed-off-by: Armando Neto <abiagion@redhat.com>