### PR TITLE
Test installation_TestInstallWithCA_DNS2

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -62,14 +62,98 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-27/temp_commit:
+  fedora-27/test_installation_TestInstallWithCA_DNS2_1:
     requires: [fedora-27/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-27/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
         template: *ci-master-f27
-        timeout: 3600
-        topology: *master_1repl_1client
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-27/test_installation_TestInstallWithCA_DNS2_2:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-27/test_installation_TestInstallWithCA_DNS2_3:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-27/test_installation_TestInstallWithCA_DNS2_4:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-27/test_installation_TestInstallWithCA_DNS2_5:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-27/test_installation_TestInstallWithCA_DNS2_6:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-27/test_installation_TestInstallWithCA_DNS2_7:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  fedora-27/test_installation_TestInstallWithCA_DNS2_8:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA_DNS2
+        template: *ci-master-f27
+        timeout: 10800
+        topology: *master_3repl_1client


### PR DESCRIPTION
Confirming that ipa-4-6 template can be downloaded and
test_installation_TestInstallWithCA_DNS2_1 failure is related to a
problem in the infra.

Signed-off-by: Armando Neto <abiagion@redhat.com>