### PR TITLE
Test for dns_lookup_kdc

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/temp_commit.yaml

--- a/ipatests/prci_definitions/temp_commit.yaml
+++ b/ipatests/prci_definitions/temp_commit.yaml
@@ -68,7 +68,7 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-latest/build_url}'
-        test_suite: test_integration/test_REPLACEME.py
+        test_suite: test_integration/test_installation_client.py
         template: *ci-master-latest
         timeout: 3600
-        topology: *master_1repl_1client
+        topology: *master_3client

--- a/ipatests/test_integration/test_installation_client.py
+++ b/ipatests/test_integration/test_installation_client.py
@@ -8,6 +8,8 @@ Module provides tests for various options of ipa-client-install.
 
 from __future__ import absolute_import
 
+import shlex
+
 from ipatests.test_integration.base import IntegrationTest
 from ipatests.pytest_ipa.integration import tasks
 
@@ -18,6 +20,40 @@ class TestInstallClient(IntegrationTest):
     @classmethod
     def install(cls, mh):
         tasks.install_master(cls.master, setup_dns=True)
+        tasks.install_client(cls.master, cls.clients[0])
+
+    def check_dns_lookup_kdc(self, client):
+        """Check that dns_lookup_kdc is never set to false.
+
+        https://pagure.io/freeipa/issue/6523
+
+        Setting dns_lookup_kdc to False would result in a hardcoded
+        configuration which is less reliable in the long run.
+        For instance, adding a trust to an Active Directory forest
+        after clients are enrolled would result in clients not being
+        able to authenticate AD users. Recycling FreeIPA servers
+        could prove problematic if the original hostnames are not
+        reused too.
+        """
+
+        result = client.run_command(
+            shlex.split("grep dns_lookup_kdc /etc/krb5.conf")
+        )
+        assert 'false' not in result.stdout_text.lower()
+        assert 'true' in result.stdout_text.lower()
+
+    def test_dns_lookup_kdc_is_true_with_default_enrollment_options(self):
+        self.check_dns_lookup_kdc(self.clients[0])
+        tasks.uninstall_client(self.clients[0])
+
+    def test_dns_lookup_kdc_is_true_with_ipa_server_on_cli(self):
+        tasks.install_client(
+            self.master,
+            self.clients[0],
+            extra_args=["--server", self.master.hostname]
+        )
+        self.check_dns_lookup_kdc(self.clients[0])
+        tasks.uninstall_client(self.clients[0])
 
     def test_client_install_with_ssh_trust_dns(self):
         """no host key verification if ssh-trust-dns option is used


### PR DESCRIPTION
ipatests: make sure dns_lookup_kdc is always true
    
    Previously, dns_lookup_kdc was only set to True if DNS
    discovery worked or if the KDC was not specified on the
    command-line.
    
    Make sure dns_lookup_kdc is always set to true.
    
    Fixes: https://pagure.io/freeipa/issue/6523