### PR TITLE
Run 389-ds integration tests with 389-ds built from copr repo:

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/nightly_latest_389ds.yaml

--- a/freeipa.spec.in
+++ b/freeipa.spec.in
@@ -103,7 +103,7 @@
 %global python_ldap_version 3.1.0-1
 # 1.4.3 moved nsslapd-db-locks to cn=bdb sub-entry
 # https://pagure.io/freeipa/issue/8515
-%global ds_version 1.4.3
+%global ds_version 2.0.2-20210118git397acd3dc.fc33
 
 # Fix for TLS 1.3 PHA, RHBZ#1775146
 %global httpd_version 2.4.41-9
@@ -241,7 +241,7 @@ BuildRequires:  openssl-devel
 BuildRequires:  libini_config-devel
 BuildRequires:  cyrus-sasl-devel
 %if ! %{ONLY_CLIENT}
-BuildRequires:  389-ds-base-devel >= %{ds_version}
+BuildRequires:  389-ds-base-devel == %{ds_version}
 BuildRequires:  samba-devel >= %{samba_version}
 BuildRequires:  libtalloc-devel
 BuildRequires:  libtevent-devel
@@ -324,7 +324,7 @@ BuildRequires:  python3-jinja2
 BuildRequires:  python3-jwcrypto >= 0.4.2
 BuildRequires:  python3-ldap >= %{python_ldap_version}
 BuildRequires:  python3-ldap >= %{python_ldap_version}
-BuildRequires:  python3-lib389 >= %{ds_version}
+BuildRequires:  python3-lib389 == %{ds_version}
 BuildRequires:  python3-libipa_hbac
 BuildRequires:  python3-libsss_nss_idmap
 BuildRequires:  python3-lxml
@@ -388,7 +388,7 @@ Requires: %{name}-client = %{version}-%{release}
 Requires: %{name}-common = %{version}-%{release}
 Requires: python3-ipaserver = %{version}-%{release}
 Requires: python3-ldap >= %{python_ldap_version}
-Requires: 389-ds-base >= %{ds_version}
+Requires: 389-ds-base == %{ds_version}
 Requires: openldap-clients > 2.4.35-4
 Requires: nss-tools >= %{nss_version}
 Requires(post): krb5-server >= %{krb5_version}
@@ -425,7 +425,7 @@ Requires: (pki-acme >= %{pki_version} if pki-ca >= 10.10.0)
 Requires: policycoreutils >= 2.1.12-5
 Requires: tar
 Requires(pre): certmonger >= %{certmonger_version}
-Requires(pre): 389-ds-base >= %{ds_version}
+Requires(pre): 389-ds-base == %{ds_version}
 Requires: fontawesome-fonts
 Requires: open-sans-fonts
 Requires: openssl

--- a/ipatests/prci_definitions/nightly_latest_389ds.yaml
+++ b/ipatests/prci_definitions/nightly_latest_389ds.yaml
@@ -300,6 +300,123 @@ jobs:
         timeout: 10800
         topology: *master_2repl_1client
 
+  389ds-fedora/test_dnssec_2:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_dnssec.py
+        template: *389ds-master-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_dnssec_3:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_dnssec.py
+        template: *389ds-master-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_dnssec_4:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_dnssec.py
+        template: *389ds-master-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_dnssec_5:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_dnssec.py
+        template: *389ds-master-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_dnssec_6:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_dnssec.py
+        template: *389ds-master-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_dnssec_7:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_dnssec.py
+        template: *389ds-master-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_dnssec_8:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_dnssec.py
+        template: *389ds-master-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_dnssec_9:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_dnssec.py
+        template: *389ds-master-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_dnssec_10:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        test_suite: test_integration/test_dnssec.py
+        template: *389ds-master-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
   389ds-fedora/test_replica_promotion_TestReplicaPromotionLevel1:
     requires: [389ds-fedora/build]
     priority: 50

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -335,7 +335,7 @@ def install_master(host, setup_dns=True, setup_kra=False, setup_adtrust=False,
         fw.enable_services(fw_services)
     if result.returncode == 0 and not external_ca:
         # external CA step 1 doesn't have DS and KDC fully configured, yet
-        enable_replication_debugging(host, log_level=73728)
+        enable_replication_debugging(host)
         enable_ds_audit_log(host, 'on')
         setup_sssd_debugging(host)
         kinit_admin(host)
@@ -462,7 +462,7 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
     result = replica.run_command(args, raiseonerr=raiseonerr,
                                  stdin_text=stdin_text)
     if result.returncode == 0:
-        enable_replication_debugging(replica, log_level=73728)
+        enable_replication_debugging(replica)
         enable_ds_audit_log(replica, 'on')
         setup_sssd_debugging(replica)
         kinit_admin(replica)

--- a/ipatests/pytest_ipa/integration/tasks.py
+++ b/ipatests/pytest_ipa/integration/tasks.py
@@ -335,7 +335,7 @@ def install_master(host, setup_dns=True, setup_kra=False, setup_adtrust=False,
         fw.enable_services(fw_services)
     if result.returncode == 0 and not external_ca:
         # external CA step 1 doesn't have DS and KDC fully configured, yet
-        enable_replication_debugging(host)
+        enable_replication_debugging(host, log_level=73728)
         enable_ds_audit_log(host, 'on')
         setup_sssd_debugging(host)
         kinit_admin(host)
@@ -462,7 +462,7 @@ def install_replica(master, replica, setup_ca=True, setup_dns=False,
     result = replica.run_command(args, raiseonerr=raiseonerr,
                                  stdin_text=stdin_text)
     if result.returncode == 0:
-        enable_replication_debugging(replica)
+        enable_replication_debugging(replica, log_level=73728)
         enable_ds_audit_log(replica, 'on')
         setup_sssd_debugging(replica)
         kinit_admin(replica)


### PR DESCRIPTION
https://copr.fedorainfracloud.org/coprs/build/1886793
389-ds-base-2.0.2-20210118git397acd3dc.fc31.src.rpm
tentative fix for sync repl issue, over 389ds master branch