### PR TITLE
WIP fallback to non-FAST

### DIFF
--- a/ipaserver/rpcserver.py
+++ b/ipaserver/rpcserver.py
@@ -1132,6 +1132,9 @@ class login_password(Backend, KerberosSession):
             elif ('kinit: Error constructing AP-REQ armor: '
                   'Matching credential not found') in str(e):
                 raise KrbPrincipalWrongFAST(principal=principal)
+            elif ('kinit: Error constructing AP-REQ armor: '
+                  'Server krbtgt/') in str(e):
+                self.kinit(principal, password, ccache_name, use_armor=False)
             raise InvalidSessionPassword(principal=principal,
                                          message=unicode(e))
 


### PR DESCRIPTION
fallback to non-FAST try in case of an error. But this would not be enough because we need FAST for OTP and should only do this fallback for trusted domain users.