### PR TITLE
Testing @389ds/389-ds-base-freeipa-tests

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -1,1 +1,1 @@
-ipatests/prci_definitions/gating.yaml
+ipatests/prci_definitions/nightly_389ds_3.yaml

--- a/ipatests/prci_definitions/nightly_389ds_3.yaml
+++ b/ipatests/prci_definitions/nightly_389ds_3.yaml
@@ -1,0 +1,658 @@
+topologies:
+  build: &build
+    name: build
+    cpu: 2
+    memory: 3800
+  master_1repl: &master_1repl
+    name: master_1repl
+    cpu: 4
+    memory: 6750
+  master_1repl_1client: &master_1repl_1client
+    name: master_1repl_1client
+    cpu: 4
+    memory: 8000
+  ipaserver: &ipaserver
+    name: ipaserver
+    cpu: 2
+    memory: 2750
+  master_2repl_1client: &master_2repl_1client
+    name: master_2repl_1client
+    cpu: 5
+    memory: 10750
+  master_3repl_1client: &master_3repl_1client
+    name: master_3repl_1client
+    cpu: 6
+    memory: 13500
+
+jobs:
+  389ds-fedora/build:
+    requires: []
+    priority: 100
+    job:
+      class: Build
+      args:
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        git_repo: '{git_repo}'
+        git_refspec: '{git_refspec}'
+        template: &ci-master-latest
+          name: freeipa/ci-master-f38
+          version: 0.0.1
+        timeout: 1800
+        topology: *build
+
+  389ds-fedora/simple_replication:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_simple_replication.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  389ds-fedora/test_commands:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_commands.py
+        template: *ci-master-latest
+        timeout: 5400
+        topology: *master_1repl_1client
+
+  389ds-fedora/test_server_del:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_server_del.py
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_installation_TestInstallWithCA1:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_installation.py::TestInstallWithCA1
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_caless_TestServerInstall:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_caless.py::TestServerInstall
+        template: *ci-master-latest
+        timeout: 12000
+        topology: *master_1repl
+
+  389ds-fedora/test_caless_TestReplicaInstall:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_caless.py::TestReplicaInstall
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_caless_TestClientInstall:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_caless.py::TestClientInstall
+        template: *ci-master-latest
+        timeout: 5400
+        # actually master_1client
+        topology: *master_1repl_1client
+
+  389ds-fedora/test_caless_TestCertInstall:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_caless.py::TestCertInstall
+        template: *ci-master-latest
+        timeout: 5400
+        topology: *master_1repl
+
+  389ds-fedora/test_backup_and_restore_TestUserRootFilesOwnershipPermission:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_backup_and_restore.py::TestUserRootFilesOwnershipPermission
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestore:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestore
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestoreWithDNSSEC:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_backup_and_restore_TestBackupReinstallRestoreWithDNSSEC:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestoreWithDNS:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_backup_and_restore_TestBackupReinstallRestoreWithDNS:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestoreWithKRA:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_backup_and_restore_TestBackupReinstallRestoreWithKRA:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestoreWithReplica:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithReplica
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_backup_and_restore_TestBackupAndRestoreDMPassword:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_backup_and_restore.py::TestBackupAndRestoreDMPassword
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_backup_and_restore_TestReplicaInstallAfterRestore:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_backup_and_restore.py::TestReplicaInstallAfterRestore
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_dnssec:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_dnssec.py
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_replica_promotion_TestReplicaPromotionLevel1:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replica_promotion.py::TestReplicaPromotionLevel1
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_replica_promotion_TestProhibitReplicaUninstallation:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replica_promotion.py::TestProhibitReplicaUninstallation
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_replica_promotion_TestHiddenReplicaPromotion:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replica_promotion.py::TestHiddenReplicaPromotion
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_2repl_1client
+
+  389ds-fedora/test_upgrade:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_upgrade.py
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl
+
+  389ds-fedora/test_topology_TestCASpecificRUVs:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_topology.py::TestCASpecificRUVs
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_topology_TestTopologyOptions:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_topology.py::TestTopologyOptions
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_replication_layouts_TestLineTopologyWithoutCA:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithoutCA
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_replication_layouts_TestLineTopologyWithCA:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCA
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_replication_layouts_TestLineTopologyWithCAKRA:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replication_layouts.py::TestLineTopologyWithCAKRA
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_replication_layouts.py_TestStarTopologyWithoutCA:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithoutCA
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_replication_layouts_TestStarTopologyWithCA:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCA
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_replication_layouts_TestStarTopologyWithCAKRA:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replication_layouts.py::TestStarTopologyWithCAKRA
+        template: *ci-master-latest
+        timeout: 10800
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_replication_layouts_TestCompleteTopologyWithoutCA:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithoutCA
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_replication_layouts_TestCompleteTopologyWithCA:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCA
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_replication_layouts_TestCompleteTopologyWithCAKRA:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_replication_layouts.py::TestCompleteTopologyWithCAKRA
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_3repl_1client
+
+  389ds-fedora/test_client_uninstallation:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_uninstallation.py
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl_1client
+
+  389ds-fedora/customized_ds_config_install:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_customized_ds_config_install.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  389ds-fedora/dns_locations:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_dns_locations.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_2repl_1client
+
+  389ds-fedora/external_ca_TestExternalCAdirsrvStop:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_external_ca.py::TestExternalCAdirsrvStop
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  389ds-fedora/mask:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_installation.py::TestMaskInstall
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  389ds-fedora/automember:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_automember.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  389ds-fedora/test_fips:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_fips.py
+        template: *ci-master-latest
+        timeout: 7200
+        topology: *master_1repl_1client
+
+  389ds-fedora/test_pwpolicy:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_pwpolicy.py
+        template: *ci-master-latest
+        timeout: 3600
+        topology: *master_1repl
+
+  389ds-fedora/test_external_idp:
+    requires: [389ds-fedora/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{389ds-fedora/build_url}'
+        update_packages: True
+        copr: '@389ds/389-ds-base-freeipa-tests'
+        test_suite: test_integration/test_idp.py
+        template: *ci-master-latest
+        timeout: 5000
+        topology: *master_2repl_1client


### PR DESCRIPTION
This PR is created only to run the CI tests over  today's version of 389-ds-base 3.0.0 in @389ds/389-ds-base-freeipa-tests 
 copr repository.
 